### PR TITLE
add upload to wp-content wordpress listing

### DIFF
--- a/common/wordpress-directory-listing.yaml
+++ b/common/wordpress-directory-listing.yaml
@@ -11,6 +11,7 @@ variables:
       wp-includes/
       wp-includes/images/
       wp-content/
+      wp-content/uploads/
       wp-content/themes/
       wp-content/plugins/
       wp-content/plugins/hustle/views/admin/dashboard/


### PR DESCRIPTION
Hi,

Here just a proposal to add the wp-content/uploads folder to the common wordpress listing signature.