### PR TITLE
Update apache-tomcat-open-redirect-cve-2018-11784.yaml

### DIFF
--- a/cves/apache-tomcat-open-redirect-cve-2018-11784.yaml
+++ b/cves/apache-tomcat-open-redirect-cve-2018-11784.yaml
@@ -12,7 +12,7 @@ requests:
       - User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:55.0) Gecko/20100101 Firefox/55
     detections:
       - >-
-        RegexSearch('resHeader', '(?m)^(L|l)ocation: ((http|https)://(www.)?)?bing.com')
+        RegexSearch('resHeader', '(?m)^(L|l)ocation: (((http|https):)?//(www.)?)?bing.com')
 
 reference:
   - https://www.cvebase.com/cve/2018/11784

--- a/cves/apache-tomcat-open-redirect-cve-2018-11784.yaml
+++ b/cves/apache-tomcat-open-redirect-cve-2018-11784.yaml
@@ -12,7 +12,7 @@ requests:
       - User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:55.0) Gecko/20100101 Firefox/55
     detections:
       - >-
-        StatusCode() == 302 && StringSearch('resHeader', 'bing.com') && !RegexSearch('resHeader', 'Location.*{{.Domain}}.*')
+        RegexSearch('resHeader', '(?m)^(L|l)ocation: ((http|https)://(www.)?)?bing.com')
 
 reference:
   - https://www.cvebase.com/cve/2018/11784


### PR DESCRIPTION
if redirection is on anothe endpoint with bing.com signature returns false.
example:
```Location: /login?url=%2f%2fbing.com```
maybe it is vulnerable to open redirect after log in this host but in most situation it is not vulnerable.
I edit detection part.
Now it detects without false