### PR TITLE
Update jenkins-xss-cve-2019-10475.yaml

### DIFF
--- a/cves/jenkins-xss-cve-2019-10475.yaml
+++ b/cves/jenkins-xss-cve-2019-10475.yaml
@@ -20,19 +20,6 @@ requests:
     detections:
       - >-
         StatusCode() == 200 && StringSearch("resBody", "<svg/onload=alert(1337)>") 
-  - method: GET
-    redirect: true
-    url: >-
-     {{.root}}/{{.endpoint}}?label=reallylongtring
-    detections:
-      - >-
-        StatusCode() == 200 && StringSearch("response", "reallylongtring")
-  - method: GET
-    redirect: true
-    url: >-
-     {{.root}}/{{.endpoint}}?label=reallylongtring
-    detections:
-      - >-
-        StatusCode() == 200 && StringSearch("response", "reallylongtring")
+
 references:
   - https://www.cvebase.com/cve/2019/10475


### PR DESCRIPTION
{{.root}}/{{.endpoint}}?label=reallylongtring this gives me false because if reallylongstring or reallynothing reflected in response jaeles returns output.
in %99 it is false 