### PR TITLE
Update wordpress-reflected-xss-cve-2019-20141.yaml

### DIFF
--- a/cves/wordpress-reflected-xss-cve-2019-20141.yaml
+++ b/cves/wordpress-reflected-xss-cve-2019-20141.yaml
@@ -18,6 +18,6 @@ requests:
       - User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3984.0 Safari/537.36
     detections:
       - >-
-        StringSearch("resHeaders", "<img src=x onerror=alert(1)>") 
+        StringSearch("resHeaders", "<img src=x onerror=alert(1)>") && StatusCode() != 301 && StatusCode() != 302
 references:
   - https://www.cvebase.com/cve/2019/20141


### PR DESCRIPTION
signature returns false result if host redirect to endpoint like

```
Location: Endpoint?path=/admin/data/autosuggest-remote.php?q=<img src=x onerror=alert(1)>
```
I added in detection part 

```
StringSearch("resHeaders", "<img src=x onerror=alert(1)>") && StatusCode() != 301 && StatusCode() != 302
```
now it works without false