### PR TITLE
SQLi Timeout Patch

### DIFF
--- a/fuzz/sqli/sqli-time.yaml
+++ b/fuzz/sqli/sqli-time.yaml
@@ -119,4 +119,4 @@ requests:
       - Query("[[.original]]{{.payload}}", "{{.name}}")
     detections:
       - >-
-       RegexSearch("response", "mysql_fetch_|not a valid MySQL|not a legal PLSQL identifer|mysql_connect\(\)|(SELECT\s+[^:>]+\sFROM\s+[^:>]+\sWHERE\s+)|(at\s[[:alnum:]\/\._]+\sline\s\d+)|ociparse\(\):|must be a syntactically valid variable|CFSQLTYPE|Unknown column '|Microsoft OLE DB Provider for SQL|SQL QUERY FAILURE:|Syntax error.{1,50}in query|You have an error in your SQL syntax|Unclosed quotation mark") || ResponseTime() > 8
+       RegexSearch("response", "mysql_fetch_|not a valid MySQL|not a legal PLSQL identifer|mysql_connect\(\)|(SELECT\s+[^:>]+\sFROM\s+[^:>]+\sWHERE\s+)|(at\s[[:alnum:]\/\._]+\sline\s\d+)|ociparse\(\):|must be a syntactically valid variable|CFSQLTYPE|Unknown column '|Microsoft OLE DB Provider for SQL|SQL QUERY FAILURE:|Syntax error.{1,50}in query|You have an error in your SQL syntax|Unclosed quotation mark") || ResponseTime() > 20


### PR DESCRIPTION
I noticed that the tool is riddled with SQLi false positives, and I've made a determination that the ResponseTime() function is the reason that it's creating a ton of false positives. Bumping it to 15 seconds worked about half of the time, but 20 seconds seemed like a fair change that still found true positives and reduced false positives significantly.